### PR TITLE
Fixed bug in LineModulation.oPointsDummyFunc

### DIFF
--- a/ShapeKernel/Modulations/LineModulation(1D).cs
+++ b/ShapeKernel/Modulations/LineModulation(1D).cs
@@ -5,7 +5,7 @@
 // specifically for use in Computational Engineering Models (CEM).
 //
 // For more information, please visit https://leap71.com/shapekernel
-// 
+//
 // This project is developed and maintained by LEAP 71 - © 2024 by LEAP 71
 // https://leap71.com
 //
@@ -15,8 +15,8 @@
 // We have developed this library to be used widely, for both commercial and
 // non-commercial projects alike. Therefore, have released it under a permissive
 // open-source license.
-// 
-// The LEAP 71 ShapeKernel is based on the PicoGK compact computational geometry 
+//
+// The LEAP 71 ShapeKernel is based on the PicoGK compact computational geometry
 // framework. See https://picogk.org for more information.
 //
 // LEAP 71 licenses this file to you under the Apache License, Version 2.0
@@ -29,7 +29,7 @@
 // PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
 //
 // See the License for the specific language governing permissions and
-// limitations under the License.   
+// limitations under the License.
 //
 
 
@@ -150,7 +150,7 @@ namespace Leap71
                         fCurrentRatio   = m_aDiscretePoints[i].Z;
                         fNextRatio      = m_aDiscretePoints[i + 1].Z;
                     }
-                    if (fCurrentRatio >= fRatio)
+                    if (fNextRatio >= fRatio)
                     {
                         fLowerRatio     = fCurrentRatio;
                         dS              = fRatio - fLowerRatio;
@@ -289,7 +289,7 @@ namespace Leap71
             {
                 protected float             m_fFactor;
                 protected LineModulation    m_oMod;
-                
+
 
                 protected ModulationMultiplication( float fFactor,
                                                     LineModulation oMod)


### PR DESCRIPTION
Fixed a bug where oPointsDummyFunc would pick the wrong points and end up extrapolating from them instead of picking the right points and interpolating. 

Eg, when interpolation should happen between x1 and x2, it would instead extrapolate between x2 and x3. 
In the diagram below, when trying to interpolate at input Z(x), we would end up with Z*(x) 
```
 Z
 ^             Z*
 |              \
 |      x1---Z--x2
 |                \
 |                 \
 |                  x3
 |
 +------------------------------> x
```
For another example, here is a desired modulation on a BaseCylinder for a pulley:
```c#
List<Vector3> aPoints = new List<Vector3>(){
    new Vector3(0f,     0f, fRad),
    new Vector3(fTransition,  0f, fRad),
    new Vector3(0.5f,   0f, fRadIn),
    new Vector3(1f - fTransition,  0f, fRad),
    new Vector3(1f,     0f, fRad)
};
LineModulation oPulleyShape = new LineModulation(aPoints, LineModulation.ECoord.Z, LineModulation.ECoord.X);
```

Previously this would result in an object like this:
![image](https://github.com/user-attachments/assets/c9a546e7-99ef-4bd1-81c8-3be3990c2254)

Now this results in the intended shape:
![image](https://github.com/user-attachments/assets/6c75c839-6098-4fd8-a553-1706ebe629e4)

