### PR TITLE
Add oGetRelativeFrame method to LocalFrame

### DIFF
--- a/ShapeKernel/Frames/LocalFrame.cs
+++ b/ShapeKernel/Frames/LocalFrame.cs
@@ -204,25 +204,26 @@ namespace Leap71
 
 	    /// <summary>
 	    /// Returns a new LocalFrame positioned at an offset relative to the given reference frame. 
-            /// The offset is interpreted in the reference frame's local coordinate system. 
+            /// The offset is interpreted in the reference frame's local coordinate system.
+	    /// Use caution if chaining relative frames as inaccuracies can compound. 
 	    /// </summary>
 	    /// <param name="refFrame">The LocalFrame whose local axes define the translation directions</param>
 	    /// <param name="vecLocalOffset">Translation vector in the reference frame's local coordinates</param> 
 	    /// <returns>A new LocalFrame translated relative to the reference frame</returns>
 	    public static LocalFrame oGetRelativeFrame(LocalFrame refFrame, Vector3 vecLocalOffset)
 	    {
-    	    	Vector3 vecRefX = refFrame.vecGetLocalX();
-    	   	Vector3 vecRefY = refFrame.vecGetLocalY();
-    	    	Vector3 vecRefZ = refFrame.vecGetLocalZ();
+		Vector3 vecRefX = refFrame.vecGetLocalX();
+		Vector3 vecRefY = refFrame.vecGetLocalY();
+		Vector3 vecRefZ = refFrame.vecGetLocalZ();
 
-    		Vector3 vecGlobalOffset =
-        	vecRefX * vecLocalOffset.X +
-       		vecRefY * vecLocalOffset.Y +
-        	vecRefZ * vecLocalOffset.Z;
+		Vector3 vecGlobalOffset =
+		vecRefX * vecLocalOffset.X 
+		vecRefY * vecLocalOffset.Y +
+		vecRefZ * vecLocalOffset.Z;
 
-    		Vector3 vecNewPosition = refFrame.vecGetPosition() + vecGlobalOffset;
+		Vector3 vecNewPosition = refFrame.vecGetPosition() + vecGlobalOffset;
 
-    		return new LocalFrame(vecNewPosition, refFrame.vecGetLocalZ(), refFrame.vecGetLocalX());
+		return new LocalFrame(vecNewPosition, refFrame.vecGetLocalZ(), refFrame.vecGetLocalX());
 	    }
 
 

--- a/ShapeKernel/Frames/LocalFrame.cs
+++ b/ShapeKernel/Frames/LocalFrame.cs
@@ -202,6 +202,30 @@ namespace Leap71
                 return oNewFrame;
             }
 
+	    /// <summary>
+	    /// Returns a new LocalFrame positioned at an offset relative to the given reference frame. 
+            /// The offset is interpreted in the reference frame's local coordinate system. 
+	    /// </summary>
+	    /// <param name="refFrame">The LocalFrame whose local axes define the translation directions</param>
+	    /// <param name="vecLocalOffset">Translation vector in the reference frame's local coordinates</param> 
+	    /// <returns>A new LocalFrame translated relative to the reference frame</returns>
+	    public static LocalFrame oGetRelativeFrame(LocalFrame refFrame, Vector3 vecLocalOffset)
+	    {
+    	    	Vector3 vecRefX = refFrame.vecGetLocalX();
+    	   	Vector3 vecRefY = refFrame.vecGetLocalY();
+    	    	Vector3 vecRefZ = refFrame.vecGetLocalZ();
+
+    		Vector3 vecGlobalOffset =
+        	vecRefX * vecLocalOffset.X +
+       		vecRefY * vecLocalOffset.Y +
+        	vecRefZ * vecLocalOffset.Z;
+
+    		Vector3 vecNewPosition = refFrame.vecGetPosition() + vecGlobalOffset;
+
+    		return new LocalFrame(vecNewPosition, refFrame.vecGetLocalZ(), refFrame.vecGetLocalX());
+	    }
+
+
             /// <summary>
             /// Compliments local z and local x according to a right-hand system.
             /// </summary>


### PR DESCRIPTION
This adds a static method oGetRelativeFrame to LocalFrame, which returns a new frame offset relative to the reference frame's local axes using a Vector3 input. Useful for constructing frames hierarchically or applying local translations.

Happy to make any changes that you might want! Love the project, still working on learning my way around C# and PicoGK as someone coming from 3d CAD background.